### PR TITLE
Add project_path as optional parameter

### DIFF
--- a/lib/fastlane/plugin/appconfig/actions/push_config_action.rb
+++ b/lib/fastlane/plugin/appconfig/actions/push_config_action.rb
@@ -21,6 +21,7 @@ module Fastlane
         git_repo                = params[:git_repo]
         git_ref                 = params[:git_ref]
         passphrase              = params[:passphrase]
+        project_path            = params[:project_path] || '.'
 
         title = 'Push Config'
         headings = ['Parameter', 'Value']
@@ -28,6 +29,7 @@ module Fastlane
         rows << ['bundle_id', bundle_id]
         rows << ['git_repo', git_repo]
         rows << ['git_ref', git_ref]
+        rows << ['project_path', project_path]
         table = Terminal::Table.new :title => title, :headings => headings, :rows => rows
         puts("\n" + table.to_s + "\n")
 
@@ -50,8 +52,8 @@ module Fastlane
 
         # Bundled files
         bundled_dst = "#{@@tmp_dir}/#{git_name}/#{bundle_id}"
-        copy_files(bundled_files, bundled_dst)
-        copy_and_encrypt_files(bundled_encrypted_files, bundled_dst, passphrase)
+        copy_files(bundled_files, bundled_dst, project_path)
+        copy_and_encrypt_files(bundled_encrypted_files, bundled_dst, project_path, passphrase)
 
         # Common files
         common_dst = "#{@@tmp_dir}/#{git_name}/common"
@@ -65,19 +67,19 @@ module Fastlane
         remove_tmp_dir_if_exists
       end
 
-      def self.copy_files(files, destination)
+      def self.copy_files(files, destination, project_path)
         files.each do |file|
           dst = "#{destination}/#{file}"
-          src = "#{Dir.pwd}/#{file}"
+          src = "#{Dir.pwd}/#{project_path}/#{file}"
           FileUtils.mkdir_p(File.dirname(dst))
           FileUtils.cp(src, dst)
         end
       end
 
-      def self.copy_and_encrypt_files(files, destination, passphrase)
+      def self.copy_and_encrypt_files(files, destination, project_path, passphrase)
         files.each do |file|
           dst = "#{destination}/#{file}"
-          src = "#{Dir.pwd}/#{file}"
+          src = "#{Dir.pwd}/#{project_path}/#{file}"
           FileUtils.mkdir_p(File.dirname(dst))
           FileUtils.cp(src, dst)
           encrypt(path: dst, password: passphrase)
@@ -89,7 +91,7 @@ module Fastlane
       end
 
       def self.description
-        'This action will push common, bundled, and encrypt them if necessary, to a configuration repo'
+        'This action will push common and bundled files, and encrypt them if necessary, to a configuration repo'
       end
 
       def self.authors
@@ -160,6 +162,13 @@ module Fastlane
             key: :passphrase,
             description: 'The passphrase used to encrypt the files',
             optional: false,
+            type: String
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :project_path,
+            default_value: '.',
+            description: 'The path to the project directory relative to the root directory (useful for React Native style setups where the root directory is not the project directory)',
+            optional: true,
             type: String
           )
         ]

--- a/lib/fastlane/plugin/appconfig/version.rb
+++ b/lib/fastlane/plugin/appconfig/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Appconfig
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
In some cases, the folder executing `fastlane` is not the folder where the actual project resides. For example, with `React Native` setups, it's fairly common practice to have the following folder structure:

```
root
|__ android
|__ ios
|__ fastlane
```

Without being able to pass a path to the project (relative to the root directory of the repository) the AppConfig script, as-is, tries to put the files that it copes into the project assuming that the project is in the root. 

The `project_path` parameter that has been added will default to being `.` if it is not specified as a parameter. If it is defined, it should be defined as a string path relative to the root of the repository (or wherever `fastlane` is being run from).

Given the above folder structure, and running `fastlane` commands from the `root` directory, my project path for iOS would simply be `ios`. If the actual xcode project was in `ios/app`, our `project_path` would reflect that as `ios/app`.

You should not add leading or trailing slashes.

In the event that the parameter is not passed in, again, it will default to `.`, which is entirely valid. This means your project files will be copied to `myProj/./EncryptedFiles` or what ever file paths you have. The `/./` is perfectly valid in this case, though it is redundant.

Feel free to address any questions or concerns.